### PR TITLE
add critical section implementation taking high prio irqs into account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ name = "nrf-mpsl"
 version = "0.1.0"
 dependencies = [
  "cortex-m",
+ "critical-section",
  "defmt",
  "embassy-nrf",
  "embassy-sync",

--- a/nrf-mpsl/Cargo.toml
+++ b/nrf-mpsl/Cargo.toml
@@ -15,10 +15,12 @@ nrf52820 = ["nrf52820-pac", "embassy-nrf/nrf52820"]
 nrf52832 = ["nrf52832-pac", "embassy-nrf/nrf52832"]
 nrf52833 = ["nrf52833-pac", "embassy-nrf/nrf52833"]
 nrf52840 = ["nrf52840-pac", "embassy-nrf/nrf52840"]
+critical-section-impl = ["critical-section/restore-state-bool"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.11", optional = true }
+critical-section = { version = "1.1", optional = true }
 
 cortex-m = "0.7.2"
 

--- a/nrf-mpsl/src/critical_section_impl.rs
+++ b/nrf-mpsl/src/critical_section_impl.rs
@@ -1,0 +1,76 @@
+use core::arch::asm;
+use core::sync::atomic::{compiler_fence, AtomicBool, Ordering};
+
+use crate::pac::{Interrupt, NVIC};
+
+const RESERVED_IRQS: u32 =
+    (1 << (Interrupt::RADIO as u8)) | (1 << (Interrupt::RTC0 as u8)) | (1 << (Interrupt::TIMER0 as u8));
+
+static CS_FLAG: AtomicBool = AtomicBool::new(false);
+static mut CS_MASK: [u32; 2] = [0; 2];
+
+#[inline]
+unsafe fn raw_critical_section<R>(f: impl FnOnce() -> R) -> R {
+    // TODO: assert that we're in privileged level
+    // Needed because disabling irqs in non-privileged level is a noop, which would break safety.
+
+    let primask: u32;
+    asm!("mrs {}, PRIMASK", out(reg) primask);
+
+    asm!("cpsid i");
+
+    // Prevent compiler from reordering operations inside/outside the critical section.
+    compiler_fence(Ordering::SeqCst);
+
+    let r = f();
+
+    compiler_fence(Ordering::SeqCst);
+
+    if primask & 1 == 0 {
+        asm!("cpsie i");
+    }
+
+    r
+}
+
+struct CriticalSection;
+critical_section::set_impl!(CriticalSection);
+
+unsafe impl critical_section::Impl for CriticalSection {
+    unsafe fn acquire() -> bool {
+        let nvic = &*NVIC::PTR;
+        let nested_cs = CS_FLAG.load(Ordering::SeqCst);
+
+        if !nested_cs {
+            raw_critical_section(|| {
+                CS_FLAG.store(true, Ordering::Relaxed);
+
+                // Store the state of irqs.
+                CS_MASK[0] = nvic.icer[0].read();
+                CS_MASK[1] = nvic.icer[1].read();
+
+                // Disable only not-reserved irqs.
+                nvic.icer[0].write(!RESERVED_IRQS);
+                nvic.icer[1].write(0xFFFF_FFFF);
+            });
+        }
+
+        compiler_fence(Ordering::SeqCst);
+
+        nested_cs
+    }
+
+    unsafe fn release(nested_cs: bool) {
+        compiler_fence(Ordering::SeqCst);
+
+        let nvic = &*NVIC::PTR;
+        if !nested_cs {
+            raw_critical_section(|| {
+                CS_FLAG.store(false, Ordering::Relaxed);
+                // restore only non-reserved irqs.
+                nvic.iser[0].write(CS_MASK[0] & !RESERVED_IRQS);
+                nvic.iser[1].write(CS_MASK[1]);
+            });
+        }
+    }
+}

--- a/nrf-mpsl/src/lib.rs
+++ b/nrf-mpsl/src/lib.rs
@@ -60,6 +60,9 @@ mod hfclk;
 mod mpsl;
 mod temp;
 
+#[cfg(feature = "critical-section-impl")]
+mod critical_section_impl;
+
 pub use error::*;
 pub use hfclk::*;
 pub use mpsl::*;


### PR DESCRIPTION
This is required to prevent a SDC panic if radio is blocked for too long