### PR TITLE
use patch for bt-hci

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", branch = 
 embassy-time = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
 embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
 embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
+bt-hci = { git = "https://github.com/alexmoon/bt-hci.git" }

--- a/nrf-sdc/Cargo.toml
+++ b/nrf-sdc/Cargo.toml
@@ -33,6 +33,6 @@ embassy-sync = "0.5.0"
 embassy-hal-internal = "0.1.0"
 critical-section = "1.1.1"
 rand_core = "0.6.4"
-bt-hci = { git = "https://github.com/alexmoon/bt-hci.git" }
 embedded-io = "0.6.0"
 embedded-io-async = "0.6.0"
+bt-hci = "0.1.0"


### PR DESCRIPTION
Makes it easier to use bt-hci and nrf-sdc outside this crate.