### PR TITLE
Impl `Send` for `MultiProtocolServiceLayer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "embedded-io-async",
  "futures-intrusive",
  "heapless",
+ "log",
 ]
 
 [[package]]

--- a/examples/src/bin/adv-simple.rs
+++ b/examples/src/bin/adv-simple.rs
@@ -27,8 +27,8 @@ bind_interrupts!(struct Irqs {
 
 fn build_sdc<'d, const N: usize>(
     p: nrf_sdc::Peripherals<'d>,
-    rng: &'d RngPool<'d>,
-    mpsl: &'d MultiprotocolServiceLayer<'d>,
+    rng: &'d RngPool,
+    mpsl: &'d MultiprotocolServiceLayer,
     mem: &'d mut sdc::Mem<N>,
 ) -> Result<nrf_sdc::SoftdeviceController<'d>, nrf_sdc::Error> {
     sdc::Builder::new()?.support_adv()?.build(p, rng, mpsl, mem)

--- a/nrf-mpsl/src/fmt.rs
+++ b/nrf-mpsl/src/fmt.rs
@@ -198,6 +198,7 @@ macro_rules! unwrap {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct NoneError;
 
+#[allow(unused)]
 pub trait Try {
     type Ok;
     type Error;

--- a/nrf-mpsl/src/mpsl.rs
+++ b/nrf-mpsl/src/mpsl.rs
@@ -52,8 +52,8 @@ impl<'d> Peripherals<'d> {
 }
 
 pub struct MultiprotocolServiceLayer<'d> {
-    // Prevent Send, Sync
-    _private: PhantomData<&'d *mut ()>,
+    // Prevent Sync
+    _private: PhantomData<core::cell::UnsafeCell<&'d ()>>,
 }
 
 unsafe extern "C" fn assert_handler(file: *const core::ffi::c_char, line: u32) {
@@ -80,11 +80,6 @@ impl<'d> MultiprotocolServiceLayer<'d> {
             + Binding<interrupt::typelevel::RTC0, HighPrioInterruptHandler>
             + Binding<interrupt::typelevel::POWER_CLOCK, ClockInterruptHandler>,
     {
-        assert!(
-            cortex_m::peripheral::SCB::vect_active() == cortex_m::peripheral::scb::VectActive::ThreadMode,
-            "MultiprotocolServiceLayer must be initialized from thread mode"
-        );
-
         // Peripherals are used by the MPSL library, so we merely take ownership and ignore them
         let _ = p;
 

--- a/nrf-sdc/Cargo.toml
+++ b/nrf-sdc/Cargo.toml
@@ -20,6 +20,7 @@ peripheral = ["nrf-sdc-sys/peripheral"]
 central = ["nrf-sdc-sys/central"]
 
 defmt = ["dep:defmt", "nrf-mpsl/defmt", "bt-hci/defmt"]
+log = ["dep:log", "nrf-mpsl/log", "bt-hci/log"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }

--- a/nrf-sdc/src/fmt.rs
+++ b/nrf-sdc/src/fmt.rs
@@ -198,6 +198,7 @@ macro_rules! unwrap {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct NoneError;
 
+#[allow(unused)]
 pub trait Try {
     type Ok;
     type Error;

--- a/nrf-sdc/src/sdc.rs
+++ b/nrf-sdc/src/sdc.rs
@@ -11,7 +11,7 @@ use bt_hci::cmd::Cmd;
 use bt_hci::controller::Controller;
 use bt_hci::{AsHciBytes, FixedSizeValue, FromHciBytes, WriteHci};
 use embassy_nrf::{peripherals, Peripheral, PeripheralRef};
-use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::signal::Signal;
 use embassy_sync::waitqueue::AtomicWaker;
 use nrf_mpsl::MultiprotocolServiceLayer;
@@ -433,7 +433,7 @@ impl Builder {
 pub struct SoftdeviceController<'d> {
     using_ext_adv_cmds: RefCell<Option<bool>>,
     periodic_adv_response_data_in_progress: AtomicBool,
-    periodic_adv_response_data_complete: Signal<ThreadModeRawMutex, (bt_hci::param::Status, bt_hci::param::SyncHandle)>,
+    periodic_adv_response_data_complete: Signal<NoopRawMutex, (bt_hci::param::Status, bt_hci::param::SyncHandle)>,
     // Prevent Send, Sync
     _private: PhantomData<&'d *mut ()>,
 }


### PR DESCRIPTION
It turns out that the `SoftdeviceController` can't be `Send` because it effectively has a shared reference to the `MultiProtocolServiceLayer` which is `!Sync`. If `SoftdeviceController` were send you could wrap it in a `Mutex` and call into it from another thread which would violate the safety of the MPSL.