### PR TITLE
Use "stable" toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "1.79"
+channel = "stable"
 components = [ "rust-src", "rustfmt", "llvm-tools-preview" ]
 targets = [
     "thumbv7em-none-eabi",


### PR DESCRIPTION
As MSRV should be guarded by `rust-version` in Cargo.toml, switch to 'stable' to not be stuck with 1.79.