### PR TITLE
mpsl: Use correct EGU peripheral for nrf52 devices and initialize IRQs internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ opt-level = 'z'
 overflow-checks = false
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
-embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy.git", branch = "main" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "8803128707b8bd9fc9dcea392a62dfd42aa822d2" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "8803128707b8bd9fc9dcea392a62dfd42aa822d2" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "8803128707b8bd9fc9dcea392a62dfd42aa822d2" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "8803128707b8bd9fc9dcea392a62dfd42aa822d2" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "8803128707b8bd9fc9dcea392a62dfd42aa822d2" }
+embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "8803128707b8bd9fc9dcea392a62dfd42aa822d2" }
+embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy.git", rev = "8803128707b8bd9fc9dcea392a62dfd42aa822d2" }
 #
 #embassy-executor = { path = "../embassy/embassy-executor" }
 #embassy-nrf = {path = "../embassy/embassy-nrf"}

--- a/examples/src/bin/adv-simple.rs
+++ b/examples/src/bin/adv-simple.rs
@@ -19,7 +19,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<RNG>;
-    SWI0_EGU0 => mpsl::LowPrioInterruptHandler;
+    SWI5_EGU5 => mpsl::LowPrioInterruptHandler;
     POWER_CLOCK => mpsl::ClockInterruptHandler;
     RADIO => mpsl::HighPrioInterruptHandler;
     TIMER0 => mpsl::HighPrioInterruptHandler;

--- a/examples/src/bin/adv-simple.rs
+++ b/examples/src/bin/adv-simple.rs
@@ -19,11 +19,6 @@ use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<RNG>;
-    SWI5_EGU5 => mpsl::LowPrioInterruptHandler;
-    POWER_CLOCK => mpsl::ClockInterruptHandler;
-    RADIO => mpsl::HighPrioInterruptHandler;
-    TIMER0 => mpsl::HighPrioInterruptHandler;
-    RTC0 => mpsl::HighPrioInterruptHandler;
 });
 
 fn build_sdc<'d, const N: usize>(
@@ -73,7 +68,7 @@ async fn main(spawner: Spawner) {
         skip_wait_lfclk_started: mpsl::raw::MPSL_DEFAULT_SKIP_WAIT_LFCLK_STARTED != 0,
     };
     static MPSL: StaticCell<MultiprotocolServiceLayer> = StaticCell::new();
-    let mpsl = MPSL.init(unwrap!(mpsl::MultiprotocolServiceLayer::new(mpsl_p, Irqs, lfclk_cfg)));
+    let mpsl = MPSL.init(unwrap!(mpsl::MultiprotocolServiceLayer::new(mpsl_p, lfclk_cfg)));
     spawner.must_spawn(mpsl_task(&*mpsl));
 
     let sdc_p = sdc::Peripherals::new(

--- a/examples/src/bin/flash.rs
+++ b/examples/src/bin/flash.rs
@@ -3,20 +3,11 @@
 
 use defmt::{info, unwrap};
 use embassy_executor::Spawner;
-use embassy_nrf::bind_interrupts;
 use futures::pin_mut;
 use mpsl::{pac, Flash, MultiprotocolServiceLayer};
 use nrf_sdc::mpsl;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
-
-bind_interrupts!(struct Irqs {
-    SWI5_EGU5 => mpsl::LowPrioInterruptHandler;
-    POWER_CLOCK => mpsl::ClockInterruptHandler;
-    RADIO => mpsl::HighPrioInterruptHandler;
-    TIMER0 => mpsl::HighPrioInterruptHandler;
-    RTC0 => mpsl::HighPrioInterruptHandler;
-});
 
 #[embassy_executor::task]
 async fn mpsl_task(mpsl: &'static MultiprotocolServiceLayer<'static>) -> ! {
@@ -60,7 +51,6 @@ async fn main(spawner: Spawner) {
 
     let mpsl = MPSL.init(unwrap!(mpsl::MultiprotocolServiceLayer::with_timeslots(
         mpsl_p,
-        Irqs,
         lfclk_cfg,
         SESSION_MEM.init(mpsl::SessionMem::new())
     )));

--- a/examples/src/bin/flash.rs
+++ b/examples/src/bin/flash.rs
@@ -11,7 +11,7 @@ use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {
-    SWI0_EGU0 => mpsl::LowPrioInterruptHandler;
+    SWI5_EGU5 => mpsl::LowPrioInterruptHandler;
     POWER_CLOCK => mpsl::ClockInterruptHandler;
     RADIO => mpsl::HighPrioInterruptHandler;
     TIMER0 => mpsl::HighPrioInterruptHandler;

--- a/nrf-mpsl/src/mpsl.rs
+++ b/nrf-mpsl/src/mpsl.rs
@@ -16,7 +16,10 @@ use crate::{hfclk, pac, raw, temp};
 static WAKER: AtomicWaker = AtomicWaker::new();
 
 bind_interrupts!(struct Irqs {
+    #[cfg(not(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811")))]
     SWI5_EGU5 => LowPrioInterruptHandler;
+    #[cfg(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811"))]
+    SWI5 => LowPrioInterruptHandler;
     POWER_CLOCK => ClockInterruptHandler;
     RADIO => HighPrioInterruptHandler;
     TIMER0 => HighPrioInterruptHandler;
@@ -89,7 +92,10 @@ impl<'d> MultiprotocolServiceLayer<'d> {
         // Peripherals are used by the MPSL library, so we merely take ownership and ignore them
         let _ = p;
 
+        #[cfg(not(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811")))]
         let irq = interrupt::SWI5_EGU5;
+        #[cfg(any(feature = "nrf52805", feature = "nrf52810", feature = "nrf52811"))]
+        let irq = interrupt::SWI5;
 
         irq.set_priority(Priority::P4);
         irq.unpend();


### PR DESCRIPTION
Firstly, fix mpls to use correct EGU instance - EGU5 instance is used on nrf52-series. (EGU0 is used for nrf53).

Now, as I had to make this fix in multiple places, I managed to move Irq registration into library itself, which allows us to get rid of `Irq` argument from various mpsl setup functions. While this makes code somewhat less error-prone and simpler, it has also one drawback - when one manages to declare duplicate IRQs, we don't get compile-time errors, but instead we'll see errors during link:
```
warning: Linking globals named 'SWI5_EGU5': symbol multiply defined!
warning: Linking globals named 'POWER_CLOCK': symbol multiply defined!
```