### PR TITLE
Update to use nrf-pac instead of nrf-rs pacs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -188,7 +188,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -222,7 +222,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "defmt",
  "embassy-futures",
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.6.1"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -302,18 +302,18 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.1"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 
 [[package]]
 name = "embassy-hal-internal"
@@ -327,7 +327,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-internal"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -360,25 +360,14 @@ dependencies = [
  "embedded-storage",
  "embedded-storage-async",
  "fixed",
- "nrf51-pac",
- "nrf52805-pac",
- "nrf52810-pac",
- "nrf52811-pac",
- "nrf52820-pac",
- "nrf52832-pac",
- "nrf52833-pac",
- "nrf52840-pac",
- "nrf5340-app-pac",
- "nrf5340-net-pac",
- "nrf9120-pac",
- "nrf9160-pac",
+ "nrf-pac",
  "rand_core",
 ]
 
 [[package]]
 name = "embassy-sync"
 version = "0.6.0"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -392,7 +381,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.3.2"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -410,7 +399,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "document-features",
 ]
@@ -418,12 +407,12 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?branch=main#398119ae43fdea147c43e72a5dea1fc83cb37340"
+source = "git+https://github.com/embassy-rs/embassy.git?branch=main#bffe7cf8a6b9c59475c0d8d2f2f8f9e88ad22087"
 dependencies = [
  "defmt",
 ]
@@ -715,13 +704,6 @@ dependencies = [
  "embedded-storage-async",
  "log",
  "nrf-mpsl-sys",
- "nrf52805-pac",
- "nrf52810-pac",
- "nrf52811-pac",
- "nrf52820-pac",
- "nrf52832-pac",
- "nrf52833-pac",
- "nrf52840-pac",
 ]
 
 [[package]]
@@ -730,6 +712,15 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "doxygen-rs",
+]
+
+[[package]]
+name = "nrf-pac"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/nrf-pac?rev=875a29629cc1c87aae00cfea647a956b3807d8be#875a29629cc1c87aae00cfea647a956b3807d8be"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
 ]
 
 [[package]]
@@ -781,138 +772,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nrf51-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137f187dc6ee482e27312086bd3c3a83e1c273512782cf131a61957f72fc4219"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf52805-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2da657648039d59f4de6bc31b948dd3a5d03b32529a4d5d19d9e2dd9d4bfa6c"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf52810-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26b12d5af17a9f4bb9a06ca9a1f814bca3d67bc8715b23f8dc230b09a227666"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf52811-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4179b2a7ed0b2fd5e109d0fab9b4fc55b3936b2a4916a9306d22e5bc8dc1fd8f"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf52820-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4791cff995e6419a5ad1aebc3b3c9539d79125ca85eb5bfd2cff9b470b81071"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf52832-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0242b685c9c15648fb803e155628f42ace457478b2cb930868f40cae2db925e0"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf52833-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e1358255b360cdc816dd7b6ef81be8c8499c0998277e5249bed222bd0f5241"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf52840-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30713f36f1be02e5bc9abefa30eae4a1f943d810f199d4923d3ad062d1be1b3d"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf5340-app-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c88824573cd150fe9f27c1a48cea31a8cb24d3322df488875775143618c087a"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf5340-net-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c03e44df22fe5888109fe42e523162c7059adf4d30860f4f73ecc8b1fc16fe"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf9120-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c012f18dc278aa33741722d374bc84e3d2d7694e29745f0bb83e56b2d6faf9b"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "nrf9160-pac"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7344d74afb5684e00c48d175cad9619f36d629cfb0687d33b4d1bb86fba688f4"
-dependencies = [
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,7 +820,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -975,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -993,12 +852,12 @@ checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1027,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1060,9 +919,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1169,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1180,22 +1039,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/examples/src/bin/flash.rs
+++ b/examples/src/bin/flash.rs
@@ -5,7 +5,7 @@ use defmt::{info, unwrap};
 use embassy_executor::Spawner;
 use embassy_nrf::bind_interrupts;
 use futures::pin_mut;
-use mpsl::{pac, Flash, MultiprotocolServiceLayer};
+use mpsl::{Flash, MultiprotocolServiceLayer};
 use nrf_sdc::mpsl;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
@@ -36,18 +36,8 @@ const ERASE_STOP: u32 = ERASE_START + 0x2000;
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
     let p = embassy_nrf::init(Default::default());
-    let pac_p = pac::Peripherals::take().unwrap();
 
-    let mpsl_p = mpsl::Peripherals::new(
-        pac_p.CLOCK,
-        pac_p.RADIO,
-        p.RTC0,
-        p.TIMER0,
-        p.TEMP,
-        p.PPI_CH19,
-        p.PPI_CH30,
-        p.PPI_CH31,
-    );
+    let mpsl_p = mpsl::Peripherals::new(p.RTC0, p.TIMER0, p.TEMP, p.PPI_CH19, p.PPI_CH30, p.PPI_CH31);
     let lfclk_cfg = mpsl::raw::mpsl_clock_lfclk_cfg_t {
         source: mpsl::raw::MPSL_CLOCK_LF_SRC_RC as u8,
         rc_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_CTIV as u8,

--- a/nrf-mpsl/Cargo.toml
+++ b/nrf-mpsl/Cargo.toml
@@ -9,18 +9,18 @@ version = "0.1.0"
 rust-version = "1.77"
 
 [features]
-nrf52805 = ["nrf52805-pac", "embassy-nrf/nrf52805"]
-nrf52810 = ["nrf52810-pac", "embassy-nrf/nrf52810"]
-nrf52811 = ["nrf52811-pac", "embassy-nrf/nrf52811"]
-nrf52820 = ["nrf52820-pac", "embassy-nrf/nrf52820"]
-nrf52832 = ["nrf52832-pac", "embassy-nrf/nrf52832"]
-nrf52833 = ["nrf52833-pac", "embassy-nrf/nrf52833"]
-nrf52840 = ["nrf52840-pac", "embassy-nrf/nrf52840"]
+nrf52805 = ["embassy-nrf/nrf52805"]
+nrf52810 = ["embassy-nrf/nrf52810"]
+nrf52811 = ["embassy-nrf/nrf52811"]
+nrf52820 = ["embassy-nrf/nrf52820"]
+nrf52832 = ["embassy-nrf/nrf52832"]
+nrf52833 = ["embassy-nrf/nrf52833"]
+nrf52840 = ["embassy-nrf/nrf52840"]
 critical-section-impl = ["critical-section/restore-state-bool"]
 fem = ["nrf-mpsl-sys/fem"]
-"fem-simple-gpio" = ["nrf-mpsl-sys/fem-simple-gpio"]
-"fem-nrf21540-gpio" = ["nrf-mpsl-sys/fem-nrf21540-gpio"]
-"fem-nrf21540-gpio-spi" = ["nrf-mpsl-sys/fem-nrf21540-gpio-spi"]
+fem-simple-gpio = ["nrf-mpsl-sys/fem-simple-gpio"]
+fem-nrf21540-gpio = ["nrf-mpsl-sys/fem-nrf21540-gpio"]
+fem-nrf21540-gpio-spi = ["nrf-mpsl-sys/fem-nrf21540-gpio-spi"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
@@ -32,15 +32,7 @@ embedded-storage-async = "0.4.1"
 
 cortex-m = "0.7.2"
 
-nrf52805-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52810-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52811-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52820-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52832-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52833-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-nrf52840-pac  = { version = "0.12.0", features = ["rt"], optional = true }
-
 nrf-mpsl-sys = { version = "0.1.0", path = "../nrf-mpsl-sys" }
 
-embassy-nrf = { version = "0.2.0" }
+embassy-nrf = { version = "0.2.0", features = ["unstable-pac"]}
 embassy-sync = { version = "0.6.0" }

--- a/nrf-mpsl/src/critical_section_impl.rs
+++ b/nrf-mpsl/src/critical_section_impl.rs
@@ -1,7 +1,8 @@
 use core::arch::asm;
 use core::sync::atomic::{compiler_fence, AtomicBool, Ordering};
 
-use crate::pac::{Interrupt, NVIC};
+use cortex_m::peripheral::NVIC;
+use embassy_nrf::interrupt::Interrupt;
 
 const RESERVED_IRQS: u32 =
     (1 << (Interrupt::RADIO as u8)) | (1 << (Interrupt::RTC0 as u8)) | (1 << (Interrupt::TIMER0 as u8));

--- a/nrf-mpsl/src/lib.rs
+++ b/nrf-mpsl/src/lib.rs
@@ -36,20 +36,6 @@ compile_error!("No chip feature activated. You must activate exactly one of the 
 ))]
 compile_error!("Multiple chip features activated. You must activate exactly one of the following features: nrf52810, nrf52811, nrf52832, nrf52833, nrf52840");
 
-#[cfg(feature = "nrf52805")]
-pub use nrf52805_pac as pac;
-#[cfg(feature = "nrf52810")]
-pub use nrf52810_pac as pac;
-#[cfg(feature = "nrf52811")]
-pub use nrf52811_pac as pac;
-#[cfg(feature = "nrf52820")]
-pub use nrf52820_pac as pac;
-#[cfg(feature = "nrf52832")]
-pub use nrf52832_pac as pac;
-#[cfg(feature = "nrf52833")]
-pub use nrf52833_pac as pac;
-#[cfg(feature = "nrf52840")]
-pub use nrf52840_pac as pac;
 pub use nrf_mpsl_sys as raw;
 
 // This mod MUST go first, so that the others see its macros.

--- a/nrf-sdc/src/lib.rs
+++ b/nrf-sdc/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-pub use mpsl::{pac, Error, RetVal};
+pub use mpsl::{Error, RetVal};
 pub use {nrf_mpsl as mpsl, nrf_sdc_sys as raw};
 
 // This mod MUST go first, so that the others see its macros.

--- a/nrf-sdc/src/sdc.rs
+++ b/nrf-sdc/src/sdc.rs
@@ -23,15 +23,21 @@ use raw::{
     SDC_CFG_TYPE_NONE, SDC_DEFAULT_RESOURCE_CFG_TAG,
 };
 
-use crate::{pac, raw, Error, RetVal};
+use crate::{raw, Error, RetVal};
 
 static WAKER: AtomicWaker = AtomicWaker::new();
 static SDC_RNG: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
 
+/// Struct containing all peripherals required for the SDC to operate.
+///
+/// This is used to enforce at compile-time that your code doesn't use
+/// these peripherals.
+///
+/// However, there's extra restrictions that are not enforced at compile-time
+/// that you must ensure to fulfill manually:
+///
+/// - Do not use the `ECB`, `CCM` or `AAR` peripherals directly.
 pub struct Peripherals<'d> {
-    pub ecb: pac::ECB,
-    pub aar: pac::AAR,
-
     pub ppi_ch17: PeripheralRef<'d, peripherals::PPI_CH17>,
     pub ppi_ch18: PeripheralRef<'d, peripherals::PPI_CH18>,
     pub ppi_ch20: PeripheralRef<'d, peripherals::PPI_CH20>,
@@ -49,8 +55,6 @@ pub struct Peripherals<'d> {
 impl<'d> Peripherals<'d> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        ecb: pac::ECB,
-        aar: pac::AAR,
         ppi_ch17: impl Peripheral<P = peripherals::PPI_CH17> + 'd,
         ppi_ch18: impl Peripheral<P = peripherals::PPI_CH18> + 'd,
         ppi_ch20: impl Peripheral<P = peripherals::PPI_CH20> + 'd,
@@ -65,8 +69,6 @@ impl<'d> Peripherals<'d> {
         ppi_ch29: impl Peripheral<P = peripherals::PPI_CH29> + 'd,
     ) -> Self {
         Peripherals {
-            ecb,
-            aar,
             ppi_ch17: ppi_ch17.into_ref(),
             ppi_ch18: ppi_ch18.into_ref(),
             ppi_ch20: ppi_ch20.into_ref(),


### PR DESCRIPTION
Update to work with https://github.com/embassy-rs/embassy/pull/3498

- Code that doesn't do register access is changed to stable alternatives: `NVIC` from `cortex-m`, the `Interrupts` enum from `embassy-nrf`.
- Code that does raw register access is now done through `embassy_nrf::pac`. I think this is the better option even if it requires the `unstable-pac` feature, because it makes it easier to keep up to date with the PAC version. NVMC and timer regs are already pretty clean so it's unlikely we're going to get breakages there, while depending on the PAC directly means it'll need bumping the version here every time embassy-nrf bumps it.

Also as I suggested in https://github.com/embassy-rs/embassy/pull/3453 I've changed this to not require singletons for things that aren't in the HAL. (`nrf-pac` doesn't even have singletons now). If the HAL adds drivers for these in the future, we can change nrf-sdc to take the HAL singletons for them.
