### PR TITLE
Remove utf8 checks in fault handlers.

### DIFF
--- a/nrf-mpsl/src/mpsl.rs
+++ b/nrf-mpsl/src/mpsl.rs
@@ -70,7 +70,8 @@ pub struct MultiprotocolServiceLayer<'d> {
 unsafe extern "C" fn assert_handler(file: *const core::ffi::c_char, line: u32) {
     panic!(
         "MultiprotocolServiceLayer: {}:{}",
-        CStr::from_ptr(file).to_str().unwrap_or("bad filename"),
+        // SAFETY: the SDC should always give us valid utf8 strings.
+        unsafe { core::str::from_utf8_unchecked(CStr::from_ptr(file).to_bytes()) },
         line
     )
 }

--- a/nrf-sdc/src/sdc.rs
+++ b/nrf-sdc/src/sdc.rs
@@ -88,7 +88,8 @@ impl<'d> Peripherals<'d> {
 unsafe extern "C" fn fault_handler(file: *const core::ffi::c_char, line: u32) {
     panic!(
         "SoftdeviceController: {}:{}",
-        CStr::from_ptr(file).to_str().unwrap_or("bad filename"),
+        // SAFETY: the SDC should always give us valid utf8 strings.
+        unsafe { core::str::from_utf8_unchecked(CStr::from_ptr(file).to_bytes()) },
         line
     )
 }


### PR DESCRIPTION
This saves ~800 bytes in a cortex-m binary.

The softdevice should always give us valid strings, if not then something is very very wrong,
and since we're on a fault handler it doesn't matter much anyway.
