### PR TITLE
Bump to embassy-nrf-0.3, embassy-sync-0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,8 +270,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fea5ef5bed4d3468dfd44f5c9fa4cda8f54c86d4fb4ae683eacf9d39e2ea12"
 dependencies = [
  "defmt",
  "embassy-futures",
@@ -288,7 +289,8 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.7.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90327bcc66333a507f89ecc4e2d911b265c45f5c9bc241f98eee076752d35ac6"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -300,7 +302,8 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3577b1e9446f61381179a330fc5324b01d511624c55f25e3c66c9e3c626dbecf"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -311,21 +314,14 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef3bac31ec146321248a169e9c7b5799f1e0b3829c7a9b324cb4600a7438f59"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "embassy-hal-internal"
-version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -335,8 +331,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-nrf"
-version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a32ea116dc9f2e0ce5a5ec10d11e6da91114eff533e5afe144986ac823f735"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -346,7 +343,7 @@ dependencies = [
  "defmt",
  "document-features",
  "embassy-embedded-hal",
- "embassy-hal-internal 0.2.0 (git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a)",
+ "embassy-hal-internal",
  "embassy-sync",
  "embassy-time-driver",
  "embassy-time-queue-utils",
@@ -366,7 +363,8 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.6.1"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3899a6e39fa3f54bf8aaf00979f9f9c0145a522f7244810533abbb748be6ce82"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -380,7 +378,8 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -396,7 +395,8 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d45f5d833b6d98bd2aab0c2de70b18bfaa10faf661a1578fd8e5dfb15eb7eba"
 dependencies = [
  "document-features",
 ]
@@ -404,7 +404,8 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-utils"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc55c748d16908a65b166d09ce976575fb8852cf60ccd06174092b41064d8f83"
 dependencies = [
  "embassy-executor",
  "heapless",
@@ -413,7 +414,8 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=cefdbfab2f1efb0797f661a9d8cc0aa686fe881a#cefdbfab2f1efb0797f661a9d8cc0aa686fe881a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc247028eae04174b6635104a35b1ed336aabef4654f5e87a8f32327d231970"
 dependencies = [
  "defmt",
 ]
@@ -718,7 +720,8 @@ dependencies = [
 [[package]]
 name = "nrf-pac"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/nrf-pac?rev=52e3a757f06035c94291bfc42b0c03f71e4d677e#52e3a757f06035c94291bfc42b0c03f71e4d677e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d334027d6703534f2a80de0794ae435c0e029358d28278533d3935e69b221b01"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -731,7 +734,7 @@ dependencies = [
  "bt-hci",
  "critical-section",
  "defmt",
- "embassy-hal-internal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embassy-hal-internal",
  "embassy-nrf",
  "embassy-sync",
  "embedded-io",
@@ -793,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -803,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
@@ -813,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -826,18 +829,18 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -853,9 +856,9 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -989,9 +992,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1016,9 +1019,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.94"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1144,9 +1147,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ opt-level = 'z'
 overflow-checks = false
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
-embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
+#embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
+#embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
+#embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
+#embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
+#embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
+#embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
+#embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy.git", rev = "cefdbfab2f1efb0797f661a9d8cc0aa686fe881a" }
 #
 #embassy-executor = { path = "../embassy/embassy-executor" }
 #embassy-nrf = {path = "../embassy/embassy-nrf"}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,8 +16,8 @@ bt-hci = { version = "0.2.0", default-features = false }
 
 embassy-executor = { version = "0.7", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "defmt", "executor-interrupt"] }
 embassy-time = { version = "0.4", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-nrf = { version = "0.2.0", features = ["defmt", "time-driver-rtc1", "gpiote", "unstable-pac"] }
-embassy-sync = { version = "0.6.0", features = ["defmt"] }
+embassy-nrf = { version = "0.3.0", features = ["defmt", "time-driver-rtc1", "gpiote", "unstable-pac"] }
+embassy-sync = { version = "0.6.1", features = ["defmt"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4.0"

--- a/nrf-mpsl/Cargo.toml
+++ b/nrf-mpsl/Cargo.toml
@@ -34,5 +34,5 @@ cortex-m = "0.7.2"
 
 nrf-mpsl-sys = { version = "0.1.0", path = "../nrf-mpsl-sys" }
 
-embassy-nrf = { version = "0.2.0", features = ["unstable-pac"]}
-embassy-sync = { version = "0.6.0" }
+embassy-nrf = { version = "0.3.0", features = ["unstable-pac"]}
+embassy-sync = { version = "0.6.1" }

--- a/nrf-sdc/Cargo.toml
+++ b/nrf-sdc/Cargo.toml
@@ -30,8 +30,8 @@ log = { version = "0.4.11", optional = true }
 nrf-mpsl = { version = "0.1.0", path = "../nrf-mpsl" }
 nrf-sdc-sys = { version = "0.1.0", path = "../nrf-sdc-sys" }
 
-embassy-nrf = "0.2.0"
-embassy-sync = "0.6.0"
+embassy-nrf = "0.3.0"
+embassy-sync = "0.6.1"
 embassy-hal-internal = "0.2.0"
 critical-section = "1.1.1"
 rand_core = "0.6.4"


### PR DESCRIPTION
Now that embassy-nrf-0.3 has been released, use it...

There's also bindgen-0.71.1 available, but we cannot bump it due to regression: https://github.com/rust-lang/rust-bindgen/issues/3053