### PR TITLE
fix(nrf-sdc-sys): device role binaries only for nrf52

### DIFF
--- a/nrf-sdc-sys/build.rs
+++ b/nrf-sdc-sys/build.rs
@@ -256,11 +256,16 @@ fn bindgen(target: &Target, mem_fns: Rc<RefCell<Vec<u8>>>) -> bindgen::Builder {
 fn main() {
     let target = Target::new(Series::get(), env::var("TARGET").unwrap());
 
-    let role = match (cfg!(feature = "peripheral"), cfg!(feature = "central")) {
-        (true, true) => "multirole",
-        (true, false) => "peripheral",
-        (false, true) => "central",
-        (false, false) => panic!("At least one of the \"peripheral\" and/or \"central\" features must be enabled!"),
+    // Only nrf52 series have different binaries depending on the role.
+    let role = if cfg!(feature = "nrf52") {
+        match (cfg!(feature = "peripheral"), cfg!(feature = "central")) {
+            (true, true) => "multirole",
+            (true, false) => "peripheral",
+            (false, true) => "central",
+            (false, false) => panic!("At least one of the \"peripheral\" and/or \"central\" features must be enabled!"),
+        }
+    } else {
+        "multirole"
     };
 
     let mem_fns = Rc::new(RefCell::new(Vec::new()));


### PR DESCRIPTION
nRF52 devices have individual binaries for each device role (central, peripheral, multirole). Other series (nRF53, nRF54) only have a single multirole binary available in nrfxlib.

This PR changes the build process in `nrf-sdc-sys` so it always links to the `multirole` binrary when the MCU is not a nRF52.

Fixes #58 