### PR TITLE
fix(nrf-sdc-sys): bump winnow to actual minimum version

### DIFF
--- a/nrf-sdc-sys/Cargo.toml
+++ b/nrf-sdc-sys/Cargo.toml
@@ -59,4 +59,4 @@ nrf-mpsl-sys = { version = "0.1.1", path = "../nrf-mpsl-sys" }
 [build-dependencies]
 bindgen = "0.70.1"
 doxygen-rs = "0.4.2"
-winnow = "0.6.20"
+winnow = "0.6.26"


### PR DESCRIPTION
Hello, I ran into a build problem while tinkering with [rmk](https://github.com/HaoboGu/rmk).

`winnow::ModalResult` only exists since winnow [0.6.24](https://github.com/winnow-rs/winnow/blame/40af151f2f42b74f390c25946dbe5cd7365f9fc8/src/lib.rs#L153), leading to a build failure if someone depends on `nrf-sdc-sys` and doesn't happen to have another library in their dependency tree that depends on winnow `0.6.24`-`0.6.26`

The latest winnow version is 0.7.11 but I'm not familiar with the library and don't know what implications an upgrade to that version would have, so I thought I'd play it safe.
