### PR TITLE
Fix CS_LEN for nRF54LM20

### DIFF
--- a/nrf-mpsl/src/critical_section_impl.rs
+++ b/nrf-mpsl/src/critical_section_impl.rs
@@ -7,7 +7,7 @@ use embassy_nrf::interrupt::Interrupt;
 
 cfg_if::cfg_if! {
     if #[cfg(any(feature = "nrf54l-s", feature = "nrf54l-ns"))] {
-        const CS_LEN: usize = 9;
+        const CS_LEN: usize = 10;
         const RESERVED_IRQS: [u32; CS_LEN] = {
             let mut irqs = [0; CS_LEN];
             irqs[Interrupt::RADIO_0 as usize / 32] = 1  << (Interrupt::RADIO_0 as usize % 32);


### PR DESCRIPTION
nRF54LM20 has VREGUSB interrupt number =  289, which needs CS_LEN = 10

Ref: https://github.com/NordicSemiconductor/nrfx/blob/master/bsp/stable/mdk/nrf54lm20a_application.h#L126

https://github.com/NordicSemiconductor/nrfx/blob/master/bsp/stable/mdk/nrf54lm20b_application.h#L127